### PR TITLE
Handle --locked parameter. Don't pass it when rust framework <= 0.39.2

### DIFF
--- a/.github/workflows/run_long_integration_tests.yml
+++ b/.github/workflows/run_long_integration_tests.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Build
         run: |
           export PYTHONPATH=.
-          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2" "a.3" "b.1" "b.2" "b.3" "c.1" "c.2" "c.3" "c.4" "c.5" "d.1" "e.1"
+          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2" "a.3" "b.1" "b.2" "b.3" "c.1" "c.2" "c.3" "c.4" "c.5" "d.1" "e.1" "f.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     binaryen=${VERSION_BINARYEN} \
     wabt=${VERSION_WABT}
 
-RUN pip3 install tomlkit==0.11.6
+RUN pip3 install tomlkit==0.11.6 semver==2.13.0
 
 # Install rust
 RUN wget -O rustup.sh https://sh.rustup.rs && \

--- a/integration_tests/previous_builds.py
+++ b/integration_tests/previous_builds.py
@@ -259,5 +259,16 @@ previous_builds: List[PreviousBuild] = [
             "metabonding": "897b19e1990f7c487c99c12f50722febe1ee4468bcd3a7405641966dfff2791d"
         },
         docker_image="sdk-rust-contract-builder:next"
+    ),
+    PreviousBuild(
+        name="f.1",
+        project_archive_url="https://github.com/multiversx/mx-energy-competition-winners-extraction-sc/archive/refs/tags/0.1.0.zip",
+        project_relative_path_in_archive="mx-energy-competition-winners-extraction-sc-0.1.0",
+        packaged_src_url=None,
+        contract_name=None,
+        expected_code_hashes={
+            "winners-extractor": "14afb225664cc7c25e94410bf113875bd784991509fe3589eae1c078bc4fe69a"
+        },
+        docker_image="sdk-rust-contract-builder:next"
     )
 ]

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -110,7 +110,8 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     args.extend(["--no-wasm-opt"] if no_wasm_opt else [])
     # If the lock file is missing, or it needs to be updated, Cargo will exit with an error.
     # See: https://doc.rust-lang.org/cargo/commands/cargo-build.html
-    args.extend(["--locked"] if cargo_lock.exists() else [])
+    if cargo_toml.does_cargo_build_accept_locked(build_folder):
+        args.extend(["--locked"] if cargo_lock.exists() else [])
 
     logging.info(f"Building: {args}")
     return_code = subprocess.run(args, cwd=meta_folder).returncode

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -108,10 +108,11 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     args = ["cargo", "run", "build"]
     args.extend(["--target-dir", str(cargo_target_dir)])
     args.extend(["--no-wasm-opt"] if no_wasm_opt else [])
+
     # If the lock file is missing, or it needs to be updated, Cargo will exit with an error.
     # See: https://doc.rust-lang.org/cargo/commands/cargo-build.html
-    if cargo_toml.does_cargo_build_accept_locked(build_folder):
-        args.extend(["--locked"] if cargo_lock.exists() else [])
+    if cargo_toml.does_cargo_build_support_locked(build_folder) and cargo_lock.exists():
+        args.append("--locked")
 
     logging.info(f"Building: {args}")
     return_code = subprocess.run(args, cwd=meta_folder).returncode

--- a/multiversx_sdk_rust_contract_builder/cargo_toml.py
+++ b/multiversx_sdk_rust_contract_builder/cargo_toml.py
@@ -67,7 +67,7 @@ def does_cargo_build_support_locked(contract_folder: Path) -> bool:
 
 
 def _normalize_rust_framework_version(version: str) -> str:
-    version_parts = version.split(".")
+    version_parts = version.strip('^').strip('=').split(".")
     if len(version_parts) == 2:
         version += ".0"
     return version

--- a/multiversx_sdk_rust_contract_builder/cargo_toml.py
+++ b/multiversx_sdk_rust_contract_builder/cargo_toml.py
@@ -48,15 +48,26 @@ def remove_dev_dependencies_sections(file: Path):
         file.write_text(tomlkit.dumps(toml))
 
 
-def does_cargo_build_accept_locked(contract_folder: Path) -> bool:
+def does_cargo_build_support_locked(contract_folder: Path) -> bool:
     file = contract_folder / "Cargo.toml"
     toml = tomlkit.parse(file.read_text())
 
     framework_version_old: str = str(toml.get("dependencies", {}).get("elrond-wasm", {}).get("version", ""))
     framework_version_new: str = str(toml.get("dependencies", {}).get("multiversx-sc", {}).get("version", ""))
     framework_version: str = framework_version_old or framework_version_new
+    framework_version = _normalize_rust_framework_version(framework_version)
 
-    supports_locked: bool = semver.compare(framework_version, "0.38.0") <= 0
+    # Before this version, --locked was ignored.
+    # On this version, using --locked resulted in an error.
+    # After this version, --locked is supported.
+    supports_locked: bool = semver.compare(framework_version, "0.39.2") > 0
 
-    logging.info(f"does_cargo_build_accept_locked({contract_folder}), framework version = {framework_version}? {supports_locked}")
+    logging.info(f"does_cargo_build_support_locked({contract_folder}), framework version = {framework_version}? {supports_locked}")
     return supports_locked
+
+
+def _normalize_rust_framework_version(version: str) -> str:
+    version_parts = version.split(".")
+    if len(version_parts) == 2:
+        version += ".0"
+    return version

--- a/multiversx_sdk_rust_contract_builder/cargo_toml.py
+++ b/multiversx_sdk_rust_contract_builder/cargo_toml.py
@@ -67,7 +67,8 @@ def does_cargo_build_support_locked(contract_folder: Path) -> bool:
 
 
 def _normalize_rust_framework_version(version: str) -> str:
-    version_parts = version.strip('^').strip('=').split(".")
+    version = version.strip('^').strip('=')
+    version_parts = version.split(".")
     if len(version_parts) == 2:
         version += ".0"
     return version


### PR DESCRIPTION
Before `0.39.2`, `--locked` was ignored by `cargo run build`. On this version, using `--locked` resulted in an error. After this version, `--locked` is supported.