### PR TITLE
Use another placeholder for test files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION_RUST="nightly-2022-10-16"
 ARG VERSION_BINARYEN="105-1"
 ARG VERSION_WABT="1.0.27-1"
 # Normally, this should be "multiversx/sdk-rust-contract-builder:{{pyproject.toml:project:version}}"
-ARG CONTEXT="multiversx/sdk-rust-contract-builder:v4.1.0"
+ARG CONTEXT="multiversx/sdk-rust-contract-builder:v4.1.1"
 
 # Install dependencies (including binaryen and wabt)
 RUN apt-get update && apt-get install -y \

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -13,7 +13,7 @@ from multiversx_sdk_rust_contract_builder.codehash import \
 from multiversx_sdk_rust_contract_builder.constants import (
     CONTRACT_CONFIG_FILENAME, HARDCODED_BUILD_FOLDER,
     MAX_OUTPUT_ARTIFACTS_ARCHIVE_SIZE, MAX_PACKAGED_SOURCE_CODE_SIZE,
-    OLD_CONTRACT_CONFIG_FILENAME)
+    OLD_CONTRACT_CONFIG_FILENAME, TEST_FILES_PLACEHOLDER)
 from multiversx_sdk_rust_contract_builder.errors import ErrKnown
 from multiversx_sdk_rust_contract_builder.filesystem import (
     archive_folder, find_file_in_folder)
@@ -40,7 +40,7 @@ def build_project(
     project_within_build_folder = copy_project_folder_to_build_folder(project_folder)
 
     cargo_toml.remove_dev_dependencies_sections_from_all(project_within_build_folder)
-    source_code.replace_all_test_content_with_noop(project_within_build_folder)
+    source_code.replace_all_test_content_with_noop(project_within_build_folder, TEST_FILES_PLACEHOLDER)
 
     for contract_folder in sorted(contracts_folders):
         contract_name, contract_version = get_contract_name_and_version(contract_folder)

--- a/multiversx_sdk_rust_contract_builder/constants.py
+++ b/multiversx_sdk_rust_contract_builder/constants.py
@@ -9,3 +9,5 @@ MAX_OUTPUT_ARTIFACTS_ARCHIVE_SIZE: int = 2 * ONE_KB_IN_BYTES * 1024
 
 CONTRACT_CONFIG_FILENAME = "multiversx.json"
 OLD_CONTRACT_CONFIG_FILENAME = "elrond.json"
+
+TEST_FILES_PLACEHOLDER = "// Test files are not included in the packaged source code."

--- a/multiversx_sdk_rust_contract_builder/source_code.py
+++ b/multiversx_sdk_rust_contract_builder/source_code.py
@@ -40,7 +40,7 @@ def is_source_code_file(path: Path) -> bool:
     return False
 
 
-def replace_all_test_content_with_noop(folder: Path):
+def replace_all_test_content_with_noop(folder: Path, content: str):
     # At this moment (January 2023) we cannot completely exclude test files from the compilation
     # (if we do so, the build throws some errors, in some cases).
     # So we replace all test content with a noop function.
@@ -49,7 +49,7 @@ def replace_all_test_content_with_noop(folder: Path):
     logging.info(f"replace_all_test_content_with_noop({folder})")
     test_files = get_all_files(folder, is_test_file)
     for file in test_files:
-        file.write_text("fn _() {}")
+        file.write_text(content)
 
 
 def is_test_file(path: Path) -> bool:

--- a/multiversx_sdk_rust_contract_builder/source_code.py
+++ b/multiversx_sdk_rust_contract_builder/source_code.py
@@ -49,7 +49,7 @@ def replace_all_test_content_with_noop(folder: Path):
     logging.info(f"replace_all_test_content_with_noop({folder})")
     test_files = get_all_files(folder, is_test_file)
     for file in test_files:
-        file.write_text("fn nothing() {}")
+        file.write_text("fn _() {}")
 
 
 def is_test_file(path: Path) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-rust-contract-builder"
-version = "4.1.0"
+version = "4.1.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
For some workspaces (e.g. `mx-exchange-sc`), test files are required to be present for the compilation to work. Currently, we replace their content with a placeholder (since only their presence is required, their content is not).

**Question:** should we include _tests_ & _dev-dependencies_ in the `*.source.json` artifacts or not? The answer is **do not include them**.