### PR TITLE
Prevent two contracts from having the same name

### DIFF
--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -104,7 +104,7 @@ def get_contracts_folders(project_path: Path) -> List[Path]:
 def ensure_distinct_contract_names(contracts_folders):
     names = set()
     for folder in sorted(contracts_folders):
-        name, = get_contract_name_and_version(folder)
+        name, _ = get_contract_name_and_version(folder)
         if name in names:
             raise Exception(f"Name \"{name}\" already associated to another contract.")
         names.add(name)

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -98,7 +98,7 @@ def get_contracts_folders(project_path: Path) -> List[Path]:
     new_markers = list(project_path.glob(f"**/{CONTRACT_CONFIG_FILENAME}"))
     marker_files = old_markers + new_markers
     folders = [marker_file.parent for marker_file in marker_files]
-    return sorted(folders)
+    return sorted(set(folders))
 
 
 def ensure_distinct_contract_names(contracts_folders):

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -40,6 +40,7 @@ def build_project(
 
     outcome = BuildOutcome(metadata, options)
     contracts_folders = get_contracts_folders(project_folder)
+    ensure_distinct_contract_names(contracts_folders)
 
     # We copy the whole project folder to the build path, to ensure that all local dependencies are available.
     project_within_build_folder = copy_project_folder_to_build_folder(project_folder, build_root_folder)
@@ -98,6 +99,15 @@ def get_contracts_folders(project_path: Path) -> List[Path]:
     marker_files = old_markers + new_markers
     folders = [marker_file.parent for marker_file in marker_files]
     return sorted(folders)
+
+
+def ensure_distinct_contract_names(contracts_folders):
+    names = set()
+    for folder in sorted(contracts_folders):
+        name, = get_contract_name_and_version(folder)
+        if name in names:
+            raise Exception(f"Name \"{name}\" already associated to another contract.")
+        names.add(name)
 
 
 def copy_project_folder_to_build_folder(project_folder: Path, build_root_folder: Path):


### PR DESCRIPTION
Currently, two contracts of the project can have the same name. In this case, the contract that appears the latest in the tree view will be the one present in the `artifacts.json`. This is a dangerous behavior. The simplest way is to prevent two contracts from having the same name.