### PR TITLE
Hotfixes for M1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           file: ./Dockerfile
           tags: multiversx/sdk-rust-contract-builder:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:next"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v4.1.4"
 ARG VERSION_RUST="nightly-2022-10-16"
 ARG VERSION_BINARYEN="105-1"
 ARG VERSION_WABT="1.0.27-1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v4.1.3"
-ARG VERSION_RUST="nightly-2022-10-16"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:next"
+ARG VERSION_RUST="nightly-2023-02-20"
 ARG VERSION_BINARYEN="105-1"
 ARG VERSION_WABT="1.0.27-1"
 ARG VERSION_SC_META="0.39.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Constants
 ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:next"
-ARG VERSION_RUST="nightly-2023-02-20"
+ARG VERSION_RUST="nightly-2022-10-16"
 ARG VERSION_BINARYEN="105-1"
 ARG VERSION_WABT="1.0.27-1"
 ARG VERSION_SC_META="0.39.5"
@@ -14,6 +14,7 @@ RUN sed -i 's|http://archive.ubuntu.com|http://de.archive.ubuntu.com|g' /etc/apt
 RUN apt-get update --fix-missing && apt-get install -y \
     wget \ 
     build-essential \
+    git \
     python3.11 python-is-python3 python3-pip \
     binaryen=${VERSION_BINARYEN} \
     wabt=${VERSION_WABT}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker buildx rm multiarch
 
 For the above to work properly, make sure to install `tonistiigi/binfmt` beforehand. Please follow the official Docker documentation [here](https://docs.docker.com/build/building/multi-platform/).
 
-Note that **we only build and publish the image for `linux/amd64`**. We recommend against using a `linux/arm64` image for performing reproducible contract builds. This is because a WASM binary generated on the `linux/arm64` image _might_ differ (at the bytecode level) from one generated on the `linux/amd64` image - probably due to distinct (unfortunate) bytecode-emitting logic in the Rust compiler.
+Note that **we only build and publish the image for `linux/amd64`**. We recommend against using a `linux/arm64` image for performing reproducible contract builds. This is because a WASM binary generated on a `linux/arm64` image _might_ differ (at the bytecode level) from one generated on the recommended `linux/amd64` image - probably due to distinct (unfortunate) bytecode-emitting logic in the Rust compiler.
 
 ## Build contract using the wrapper
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker image (and wrappers) for reproducible contract builds (Rust). See [docs.m
 We use `docker buildx` to build the image:
 
 ```
-docker buildx build --output type=docker --no-cache . -t sdk-rust-contract-builder:next -f ./Dockerfile
+docker buildx build --output type=docker . -t sdk-rust-contract-builder:next -f ./Dockerfile
 ```
 
 Maintainers can publish the image as follows:
@@ -15,14 +15,14 @@ Maintainers can publish the image as follows:
 ```
 docker buildx create --name multiarch --use
 
-docker buildx build --no-cache --push --platform=linux/amd64,linux/arm64 . -t multiversx/sdk-rust-contract-builder:next -f ./Dockerfile
+docker buildx build --push --platform=linux/amd64 . -t multiversx/sdk-rust-contract-builder:next -f ./Dockerfile
 
 docker buildx rm multiarch
 ```
 
 For the above to work properly, make sure to install `tonistiigi/binfmt` beforehand. Please follow the official Docker documentation [here](https://docs.docker.com/build/building/multi-platform/).
 
-Though, note that currently (January 2023) we recommend against using the `linux/arm64` image for performing reproducible contract builds. This is because, in some (possibly rare) circumstances, a WASM binary generated on the `linux/amd64` image _might_ differ (at the bytecode level) from one generated on the `linux/arm64` image - probably due to distinct (unfortunate) bytecode-emitting logic in the Rust compiler.
+Note that **we only build and publish the image for `linux/amd64`**. We recommend against using a `linux/arm64` image for performing reproducible contract builds. This is because a WASM binary generated on the `linux/arm64` image _might_ differ (at the bytecode level) from one generated on the `linux/amd64` image - probably due to distinct (unfortunate) bytecode-emitting logic in the Rust compiler.
 
 ## Build contract using the wrapper
 

--- a/build_with_docker.py
+++ b/build_with_docker.py
@@ -20,11 +20,7 @@ def main(cli_args: List[str]):
     parser.add_argument("--packaged-src", type=str, help="source code packaged in a JSON file")
     parser.add_argument("--contract", type=str)
     parser.add_argument("--output", type=str, default=Path(os.getcwd()) / "output")
-    # Providing this parameter
-    #   (a) *might* (should, but it doesn't) speed up (subsequent) builds, but
-    #   (b) *might* (with a *very low* probability) break build determinism.
-    # As of November 2022, both (a) and (b) are still open points.
-    parser.add_argument("--cargo-target-dir", type=str)
+    # TODO: add a verbose flag
     parser.add_argument("--no-wasm-opt", action="store_true", default=False, help="do not optimize wasm files after the build (default: %(default)s)")
     parser.add_argument("--build-root", type=str, required=False, help="root path (within container) for the build (default: %(default)s)")
 
@@ -37,7 +33,6 @@ def main(cli_args: List[str]):
     packaged_src_path = Path(parsed_args.packaged_src).expanduser().resolve() if parsed_args.packaged_src else None
     contract_path = parsed_args.contract
     output_path = Path(parsed_args.output).expanduser().resolve()
-    cargo_target_dir = Path(parsed_args.cargo_target_dir).expanduser().resolve() if parsed_args.cargo_target_dir else None
     no_wasm_opt = parsed_args.no_wasm_opt
     build_root = Path(parsed_args.build_root) if parsed_args.build_root else None
 
@@ -65,8 +60,17 @@ def main(cli_args: List[str]):
     if packaged_src_path:
         docker_mount_args.extend(["--volume", f"{packaged_src_path}:/packaged-src.json"])
 
-    if cargo_target_dir:
-        docker_mount_args += ["--volume", f"{cargo_target_dir}:/rust/cargo-target-dir"]
+    mounted_cargo_target_dir = Path("/tmp/multiversx_sdk_rust_contract_builder/cargo-target-dir")
+    mounted_cargo_registry = Path("/tmp/multiversx_sdk_rust_contract_builder/cargo-registry")
+    mounted_cargo_git = Path("/tmp/multiversx_sdk_rust_contract_builder/cargo-git")
+
+    mounted_cargo_target_dir.mkdir(parents=True, exist_ok=True)
+    mounted_cargo_registry.mkdir(parents=True, exist_ok=True)
+    mounted_cargo_git.mkdir(parents=True, exist_ok=True)
+
+    docker_mount_args += ["--volume", f"{mounted_cargo_target_dir}:/rust/cargo-target-dir"]
+    docker_mount_args += ["--volume", f"{mounted_cargo_registry}:/rust/registry"]
+    docker_mount_args += ["--volume", f"{mounted_cargo_git}:/rust/git"]
 
     # Prepare entrypoint arguments
     entrypoint_args: List[str] = []

--- a/build_with_docker.py
+++ b/build_with_docker.py
@@ -20,9 +20,10 @@ def main(cli_args: List[str]):
     parser.add_argument("--packaged-src", type=str, help="source code packaged in a JSON file")
     parser.add_argument("--contract", type=str)
     parser.add_argument("--output", type=str, default=Path(os.getcwd()) / "output")
+    parser.add_argument("--cargo-target-dir", help="deprecated parameter, not used anymore")
     parser.add_argument("--no-wasm-opt", action="store_true", default=False, help="do not optimize wasm files after the build (default: %(default)s)")
     parser.add_argument("--build-root", type=str, required=False, help="root path (within container) for the build (default: %(default)s)")
-    parser.add_argument("--cargo-verbose", action="store_true", default=False, help="set CARGO_TERM_VERBOSE variable (default: %(default)s)")
+    parser.add_argument("--cargo-verbose", action="store_true", default=False, help="set 'CARGO_TERM_VERBOSE' environment variable (default: %(default)s)")
 
     # Handle CLI arguments
     parsed_args = parser.parse_args(cli_args)

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -126,7 +126,6 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     args = ["cargo", "run", "build"]
     args.extend(["--target-dir", str(cargo_target_dir)])
     args.extend(["--no-wasm-opt"] if no_wasm_opt else [])
-    args.extend(["--verbose"])
 
     # If the lock file is missing, or it needs to be updated, Cargo will exit with an error.
     # See: https://doc.rust-lang.org/cargo/commands/cargo-build.html

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -126,6 +126,7 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     args = ["cargo", "run", "build"]
     args.extend(["--target-dir", str(cargo_target_dir)])
     args.extend(["--no-wasm-opt"] if no_wasm_opt else [])
+    args.extend(["--verbose"])
 
     # If the lock file is missing, or it needs to be updated, Cargo will exit with an error.
     # See: https://doc.rust-lang.org/cargo/commands/cargo-build.html

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -133,8 +133,11 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     if cargo_toml.does_cargo_build_support_locked(build_folder) and cargo_lock.exists():
         args.append("--locked")
 
+    custom_env = os.environ.copy()
+    custom_env["RUST_BACKTRACE"] = "1"
+
     logging.info(f"Building: {args}")
-    return_code = subprocess.run(args, cwd=meta_folder).returncode
+    return_code = subprocess.run(args, cwd=meta_folder, env=custom_env).returncode
     if return_code != 0:
         raise ErrKnown(f"Failed to build contract {build_folder}. Return code: {return_code}.")
 

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -135,6 +135,8 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
 
     custom_env = os.environ.copy()
     custom_env["RUST_BACKTRACE"] = "1"
+    custom_env["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
+    custom_env["CARGO_TERM_VERBOSE"] = "true"
 
     logging.info(f"Building: {args}")
     return_code = subprocess.run(args, cwd=meta_folder, env=custom_env).returncode

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -133,9 +133,11 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
         args.append("--locked")
 
     custom_env = os.environ.copy()
-    custom_env["RUST_BACKTRACE"] = "1"
+    # Cargo will use the git executable to fetch registry indexes and git dependencies.
+    #  - https://doc.rust-lang.org/cargo/reference/config.html
+    # This is required to avoid high memory usage when fetching dependencies.
+    # - https://github.com/rust-lang/cargo/issues/10583
     custom_env["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    custom_env["CARGO_TERM_VERBOSE"] = "true"
 
     logging.info(f"Building: {args}")
     return_code = subprocess.run(args, cwd=meta_folder, env=custom_env).returncode


### PR DESCRIPTION
On Mac machines with a `M1 Pro` CPU, the docker run command was killed (`-9` exit code) due to high memory usage (our assumption). In this PR, we pass the `CARGO_NET_GIT_FETCH_WITH_CLI` environment variable to `cargo run build`. This instructs cargo to rely on the `git` executable to fetch registry indexes and git dependencies.

**We don't publish an official image for `linux/arm64` anymore.**


References:
 - https://github.com/rust-lang/cargo/issues/10583