### PR TITLE
Add support for multi-contracts

### DIFF
--- a/.github/workflows/run_long_integration_tests.yml
+++ b/.github/workflows/run_long_integration_tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: |
           export PYTHONPATH=.
-          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1"
+          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2"
 
       - name: Save artifacts
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v5.0.0"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v5.1.0"
 ARG VERSION_RUST="nightly-2023-04-24"
 ARG VERSION_BINARYEN="version_112"
 ARG DOWNLOAD_URL_BINARYEN="https://github.com/WebAssembly/binaryen/releases/download/${VERSION_BINARYEN}/binaryen-${VERSION_BINARYEN}-x86_64-linux.tar.gz"

--- a/integration_tests/previous_builds.py
+++ b/integration_tests/previous_builds.py
@@ -30,5 +30,18 @@ previous_builds: List[PreviousBuild] = [
             "adder": "9fd12f88f9474ba115fb75e9d18a8fdbc4f42147de005445048442d49c3aa725"
         },
         docker_image="sdk-rust-contract-builder:next"
+    ),
+    PreviousBuild(
+        name="a.2",
+        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/heads/add-multisig.zip",
+        project_relative_path_in_archive=None,
+        packaged_src_url=None,
+        contract_name=None,
+        expected_code_hashes={
+            "multisig": "5cc02a06d3c921a31ecbfe351a69ac2309c7c42a4a82152ee0df09cf8c4c73b6",
+            "multisig-full": "6a739f31c52fd2284ff77a8ef6f5c50f94ab8511fe1f772e5400d3c0e425a46b",
+            "multisig-view": "50da33a67b84a8b754ac8efdb30cb9424ff2173622a6d6083522c21f36bde8ac"
+        },
+        docker_image="sdk-rust-contract-builder:next"
     )
 ]

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -1,5 +1,6 @@
 import shutil
 import sys
+from pathlib import Path
 from typing import List
 
 from integration_tests.config import PARENT_OUTPUT_FOLDER
@@ -8,15 +9,21 @@ from integration_tests.shared import download_project_repository, run_docker
 
 def main(cli_args: List[str]):
     # TODO: when possible, use multiversx/mx-exchange-sc (as of May 2023, it references mx-sdk-rs < v0.41.0, thus cannot be used for testing reproducible builds v5).
-    project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/heads/main.zip", "mx-exchange-sc-main")
+    project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/heads/add-multisig.zip", "mx-exchange-sc-main")
     parent_output_using_project = PARENT_OUTPUT_FOLDER / "using-project"
     parent_output_using_packaged_src = PARENT_OUTPUT_FOLDER / "using-packaged-src"
 
     shutil.rmtree(parent_output_using_project, ignore_errors=True)
     shutil.rmtree(parent_output_using_packaged_src, ignore_errors=True)
 
-    contracts = ['adder']
+    check_project_folder_and_packaged_src_are_equivalent(project_path, parent_output_using_project, parent_output_using_packaged_src, ["adder", "multisig"])
 
+
+def check_project_folder_and_packaged_src_are_equivalent(
+        project_path: Path,
+        parent_output_using_project: Path,
+        parent_output_using_packaged_src: Path,
+        contracts: List[str]):
     for contract in contracts:
         for package_whole_project_src in [True, False]:
             output_using_project = parent_output_using_project / contract / ("whole" if package_whole_project_src else "truncated")

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -8,7 +8,7 @@ from integration_tests.shared import download_project_repository, run_docker
 
 
 def main(cli_args: List[str]):
-    # TODO: when possible, use multiversx/mx-exchange-sc (as of May 2023, it references mx-sdk-rs < v0.41.0, thus cannot be used for testing reproducible builds v5).
+    # TODO: when possible, also add multiversx/mx-exchange-sc (as of May 2023, it references mx-sdk-rs < v0.41.0, thus cannot be used for testing reproducible builds v5).
     project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/heads/add-multisig.zip", "mx-exchange-sc-main")
     parent_output_using_project = PARENT_OUTPUT_FOLDER / "using-project"
     parent_output_using_packaged_src = PARENT_OUTPUT_FOLDER / "using-packaged-src"

--- a/multiversx_sdk_rust_contract_builder/build_outcome.py
+++ b/multiversx_sdk_rust_contract_builder/build_outcome.py
@@ -55,7 +55,10 @@ class BuildOutcomeEntry:
 
     @classmethod
     def many_from_folders(cls, build_folder: Path, output_folder: Path) -> Dict[str, 'BuildOutcomeEntry']:
+        # Note: sub-contracts of multi-contracts share the same version.
         _, version = get_contract_name_and_version(build_folder)
+
+        # We consider all *.wasm files in the output folder to be standalone contracts or sub-contracts of multi-contracts.
         wasm_files = find_files_in_folder(output_folder, "*.wasm")
 
         result: Dict[str, BuildOutcomeEntry] = {}
@@ -68,6 +71,8 @@ class BuildOutcomeEntry:
             entry.bytecode_path = BuildArtifact.find_in_output(f"{contract_name}.wasm", output_folder)
             entry.abi_path = BuildArtifact.find_in_output(f"{contract_name}.abi.json", output_folder)
             entry.src_package_path = BuildArtifact.find_in_output("*.source.json", output_folder)
+
+            result[contract_name] = entry
 
         return result
 

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -82,7 +82,7 @@ def build_project(
             build_options=options.to_dict(),
         )
 
-        outcome.gather_artifacts(contract_name, contract_build_subfolder, output_subfolder)
+        outcome.gather_artifacts(contract_build_subfolder, output_subfolder)
 
     return outcome
 

--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -16,7 +16,8 @@ from multiversx_sdk_rust_contract_builder.codehash import \
 from multiversx_sdk_rust_contract_builder.constants import (
     CONTRACT_CONFIG_FILENAME, MAX_PACKAGED_SOURCE_CODE_SIZE)
 from multiversx_sdk_rust_contract_builder.errors import ErrKnown
-from multiversx_sdk_rust_contract_builder.filesystem import find_file_in_folder
+from multiversx_sdk_rust_contract_builder.filesystem import \
+    find_files_in_folder
 from multiversx_sdk_rust_contract_builder.packaged_source_code import (
     PackagedSourceCode, PackagedSourceMetadata)
 
@@ -153,8 +154,10 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
     if return_code != 0:
         raise ErrKnown(f"Failed to build contract {build_folder}. Return code: {return_code}.")
 
-    wasm_file = find_file_in_folder(cargo_output_folder, "*.wasm")
-    generate_code_hash_artifact(wasm_file)
+    # One or more WASM files should have been generated.
+    wasm_files = find_files_in_folder(cargo_output_folder, "*.wasm")
+    for wasm_file in wasm_files:
+        generate_code_hash_artifact(wasm_file)
 
     shutil.copytree(cargo_output_folder, output_folder, dirs_exist_ok=True)
 

--- a/multiversx_sdk_rust_contract_builder/filesystem.py
+++ b/multiversx_sdk_rust_contract_builder/filesystem.py
@@ -18,11 +18,11 @@ def find_files_in_folder(folder: Path, pattern: str) -> List[Path]:
     if len(files) == 0:
         raise ErrKnown(f"No file matches pattern [{pattern}] in folder {folder}")
 
-    return [Path(file).resolve() for file in files]
+    return sorted([Path(file).resolve() for file in files])
 
 
 def find_file_in_folder(folder: Path, pattern: str) -> Path:
-    files = list(folder.rglob(pattern))
+    files = sorted(list(folder.rglob(pattern)))
 
     if len(files) == 0:
         raise ErrKnown(f"No file matches pattern [{pattern}] in folder {folder}")

--- a/multiversx_sdk_rust_contract_builder/filesystem.py
+++ b/multiversx_sdk_rust_contract_builder/filesystem.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable, List, Union
 
 from multiversx_sdk_rust_contract_builder.errors import ErrKnown
 
@@ -10,6 +10,15 @@ def get_all_files(folder: Path, should_include_file: Union[Callable[[Path], bool
     paths = list(folder.rglob("*"))
     paths = [path for path in paths if path.is_file() and should_include_file(path)]
     return paths
+
+
+def find_files_in_folder(folder: Path, pattern: str) -> List[Path]:
+    files = list(folder.rglob(pattern))
+
+    if len(files) == 0:
+        raise ErrKnown(f"No file matches pattern [{pattern}] in folder {folder}")
+
+    return [Path(file).resolve() for file in files]
 
 
 def find_file_in_folder(folder: Path, pattern: str) -> Path:

--- a/multiversx_sdk_rust_contract_builder/source_code.py
+++ b/multiversx_sdk_rust_contract_builder/source_code.py
@@ -63,7 +63,7 @@ def _is_source_code_file(path: Path) -> bool:
         return True
     if path.parent.name == "meta" and path.name == "Cargo.lock":
         return False
-    if path.name in ["Cargo.toml", "Cargo.lock", CONTRACT_CONFIG_FILENAME]:
+    if path.name in ["Cargo.toml", "Cargo.lock", "multicontract.toml", CONTRACT_CONFIG_FILENAME]:
         return True
     return False
 


### PR DESCRIPTION
Related to https://github.com/multiversx/mx-sdk-rust-contract-builder/issues/31.

Now, building the `multisig` contract would result into the following `artifacts.json`:

```
{
    "buildMetadata": {
        ...
    },
    "buildOptions": {
        ...
        "specificContract": "multisig",
        "buildRootFolder": "/tmp/project"
    },
    "contracts": {
        "multisig-full": {
            "version": "0.0.0",
            "codehash": "6a739f31c52fd2284ff77a8ef6f5c50f94ab8511fe1f772e5400d3c0e425a46b",
            "artifacts": {
                "bytecode": "multisig-full.wasm",
                "abi": "multisig-full.abi.json",
                "srcPackage": "multisig-0.0.0.source.json"
            }
        },
        "multisig-view": {
            "version": "0.0.0",
            "codehash": "50da33a67b84a8b754ac8efdb30cb9424ff2173622a6d6083522c21f36bde8ac",
            "artifacts": {
                "bytecode": "multisig-view.wasm",
                "abi": "multisig-view.abi.json",
                "srcPackage": "multisig-0.0.0.source.json"
            }
        },
        "multisig": {
            "version": "0.0.0",
            "codehash": "5cc02a06d3c921a31ecbfe351a69ac2309c7c42a4a82152ee0df09cf8c4c73b6",
            "artifacts": {
                "bytecode": "multisig.wasm",
                "abi": "multisig.abi.json",
                "srcPackage": "multisig-0.0.0.source.json"
            }
        }
    }
}
```