### PR TITLE
Install pkg-config and libssl-dev on the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION_RUST="nightly-2023-05-26"
 ARG VERSION_BINARYEN="version_112"
 ARG DOWNLOAD_URL_BINARYEN="https://github.com/WebAssembly/binaryen/releases/download/${VERSION_BINARYEN}/binaryen-${VERSION_BINARYEN}-x86_64-linux.tar.gz"
 ARG VERSION_WABT="1.0.27-1"
-ARG VERSION_SC_META="0.41.0"
+ARG VERSION_SC_META="0.43.3"
 ARG TARGETPLATFORM
 
 # Install system dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v5.2.0"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v5.3.0"
 ARG VERSION_RUST="nightly-2023-05-26"
 ARG VERSION_BINARYEN="version_112"
 ARG DOWNLOAD_URL_BINARYEN="https://github.com/WebAssembly/binaryen/releases/download/${VERSION_BINARYEN}/binaryen-${VERSION_BINARYEN}-x86_64-linux.tar.gz"
@@ -15,7 +15,9 @@ RUN apt-get update --fix-missing && apt-get install -y \
     build-essential \
     git \
     python3.11 python-is-python3 python3-pip \
-    wabt=${VERSION_WABT}
+    wabt=${VERSION_WABT} \
+    pkg-config \
+    libssl-dev
 
 # Install binaryen
 RUN wget -O binaryen.tar.gz ${DOWNLOAD_URL_BINARYEN} && \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker image (and wrappers) for reproducible contract builds (Rust). See [docs.m
 We use `docker buildx` to build the image:
 
 ```
-docker buildx build --output type=docker . -t sdk-rust-contract-builder:next -f ./Dockerfile
+docker buildx build --network host  --output type=docker . -t sdk-rust-contract-builder:next -f ./Dockerfile
 ```
 
 Maintainers can publish the image as follows:
@@ -15,7 +15,7 @@ Maintainers can publish the image as follows:
 ```
 docker buildx create --name multiarch --use
 
-docker buildx build --push --platform=linux/amd64 . -t multiversx/sdk-rust-contract-builder:next -f ./Dockerfile
+docker buildx build --network host --push --platform=linux/amd64 . -t multiversx/sdk-rust-contract-builder:next -f ./Dockerfile
 
 docker buildx rm multiarch
 ```

--- a/integration_tests/shared.py
+++ b/integration_tests/shared.py
@@ -54,6 +54,7 @@ def run_docker(
     docker_mount_args += ["--volume", f"{RUST_REGISTRY}:/rust/registry"]
     docker_mount_args += ["--volume", f"{RUST_GIT}:/rust/git"]
     docker_mount_args += ["--volume", f"{RUST_TMP}:/rust/tmp"]
+    docker_mount_args += ["--network", "host"]
 
     docker_args = ["docker", "run"]
     docker_args += docker_mount_args


### PR DESCRIPTION
 - Install new packages: `pkg-config` and `libssl-dev`
 - Reference `sc-meta v0.43.3`.

It's possible that the new Docker image isn't usable for contracts that depend on, say, `mx-sdk-rs v0.41` - e.g. the following error could occur: `Cargo.lock needs to be updated but --locked was passed to prevent this`.

Related: https://github.com/multiversx/mx-sc-actions/issues/22