### PR TITLE
v6 (major release): Use a newer Rust

### DIFF
--- a/.github/workflows/run_long_integration_tests.yml
+++ b/.github/workflows/run_long_integration_tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: |
           export PYTHONPATH=.
-          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2" "a.3"
+          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2" "a.3" "a.4"
 
       - name: Save artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run_long_integration_tests.yml
+++ b/.github/workflows/run_long_integration_tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: |
           export PYTHONPATH=.
-          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1" "a.2"
+          python ./integration_tests/test_previous_builds_are_reproducible.py --selected-builds "a.1"
 
       - name: Save artifacts
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v5.3.0"
-ARG VERSION_RUST="nightly-2023-05-26"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v6.0.0-beta.0"
+ARG VERSION_RUST="nightly-2023-12-11"
 ARG VERSION_BINARYEN="version_112"
 ARG DOWNLOAD_URL_BINARYEN="https://github.com/WebAssembly/binaryen/releases/download/${VERSION_BINARYEN}/binaryen-${VERSION_BINARYEN}-x86_64-linux.tar.gz"
 ARG VERSION_WABT="1.0.27-1"
@@ -39,7 +39,7 @@ RUN wget -O rustup.sh https://sh.rustup.rs && \
     rm -rf /rust/registry
 
 # Install sc-tool
-RUN PATH="/rust/bin:${PATH}" CARGO_HOME=/rust RUSTUP_HOME=/rust cargo install multiversx-sc-meta --version ${VERSION_SC_META} && \
+RUN PATH="/rust/bin:${PATH}" CARGO_HOME=/rust RUSTUP_HOME=/rust cargo install multiversx-sc-meta --locked --version ${VERSION_SC_META} && \
     rm -rf /rust/registry
 
 COPY "multiversx_sdk_rust_contract_builder" "/multiversx_sdk_rust_contract_builder"

--- a/integration_tests/previous_builds.py
+++ b/integration_tests/previous_builds.py
@@ -60,5 +60,20 @@ previous_builds: List[PreviousBuild] = [
             "lottery-esdt": "e06b1a5c7fb71181a79e9be6b86d8ad154e5c2def4da6d2f0aa5266163823291"
         },
         docker_image="multiversx/sdk-rust-contract-builder:v5.4.0"
+    ),
+    PreviousBuild(
+        name="a.4",
+        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.5.0-beta.0.zip",
+        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.5.0-beta.0",
+        packaged_src_url=None,
+        contract_name=None,
+        expected_code_hashes={
+            "adder": "384b680df7a95ebceca02ffb3e760a2fc288dea1b802685ef15df22ae88ba15b",
+            "multisig": "d1453017d1fcac43f3b54c390b112b37af38ae840a2464d8ff68e3981da9972d",
+            "multisig-full": "e7fd6d118639e4b4381b3a667435948cd70f1f06b6ef39e227bd88349f7e7979",
+            "multisig-view": "290c9b3e374dffa33649ed46bd0b626c66f933eff9437f11f3559372d7538f85",
+            "lottery-esdt": "d4d4b6d2d797749435a4127a12d5ea16b911d6783e00cbc9faf4bace7d655c7a"
+        },
+        docker_image="sdk-rust-contract-builder:next"
     )
 ]

--- a/integration_tests/previous_builds.py
+++ b/integration_tests/previous_builds.py
@@ -48,17 +48,17 @@ previous_builds: List[PreviousBuild] = [
     ),
     PreviousBuild(
         name="a.3",
-        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.6.zip",
-        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.4.6",
+        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.7.zip",
+        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.4.7",
         packaged_src_url=None,
         contract_name=None,
         expected_code_hashes={
             "adder": "9fd12f88f9474ba115fb75e9d18a8fdbc4f42147de005445048442d49c3aa725",
-            "multisig": "b73050629c11b1f1a20ca6232abcef07897624195691552e3f2e2fce47822166",
-            "multisig-full": "37c3b90bdaa7d8d203385c91b0b5cb4d3c444ab9ec5263351978046a545854e3",
-            "multisig-view": "ebaf987b041fcda297da71291d76736e4e98a1e449e5ec37908cdc0198e8be37",
+            "multisig": "9600fc699c85fd5a24ecf28f0b8cf01dc281c81399fb018d5ad8405b7d401041",
+            "multisig-full": "9eed9c35113209fc69631cf29aac6e81f0e331132bf6e46198e679259075ad49",
+            "multisig-view": "3993cf3fb5cd18102e2b8946ea1997f6f1cc512537f453265ba1afd7378fc0c6",
             "lottery-esdt": "e06b1a5c7fb71181a79e9be6b86d8ad154e5c2def4da6d2f0aa5266163823291"
         },
-        docker_image="multiversx/sdk-rust-contract-builder:v5.3.0"
+        docker_image="multiversx/sdk-rust-contract-builder:v5.4.0"
     )
 ]

--- a/integration_tests/previous_builds.py
+++ b/integration_tests/previous_builds.py
@@ -22,29 +22,16 @@ class PreviousBuild:
 previous_builds: List[PreviousBuild] = [
     PreviousBuild(
         name="a.1",
-        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.0.zip",
-        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.4.0",
-        packaged_src_url=None,
-        contract_name=None,
-        expected_code_hashes={
-            "adder": "9fd12f88f9474ba115fb75e9d18a8fdbc4f42147de005445048442d49c3aa725",
-            "multisig": "2101bc2a7a31ea42e5ffaadd86c1640009690e93b1cb46c3566ba5eac2984e36",
-            "multisig-full": "ef468403354b6d3a728f86101354359fe6864187d216f674d99b31fc05313a39",
-            "multisig-view": "3690af76be10c0520e3c3545cde8d9ef6a15c2d0af74dbd8704b4909644049c9"
-        },
-        docker_image="multiversx/sdk-rust-contract-builder:v5.1.0"
-    ),
-    PreviousBuild(
-        name="a.2",
-        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.3.zip",
-        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.4.3",
+        project_archive_url="https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.6.zip",
+        project_relative_path_in_archive="mx-reproducible-contract-build-example-sc-0.4.6",
         packaged_src_url=None,
         contract_name=None,
         expected_code_hashes={
             "adder": "9fd12f88f9474ba115fb75e9d18a8fdbc4f42147de005445048442d49c3aa725",
             "multisig": "b73050629c11b1f1a20ca6232abcef07897624195691552e3f2e2fce47822166",
             "multisig-full": "37c3b90bdaa7d8d203385c91b0b5cb4d3c444ab9ec5263351978046a545854e3",
-            "multisig-view": "ebaf987b041fcda297da71291d76736e4e98a1e449e5ec37908cdc0198e8be37"
+            "multisig-view": "ebaf987b041fcda297da71291d76736e4e98a1e449e5ec37908cdc0198e8be37",
+            "lottery-esdt": "e06b1a5c7fb71181a79e9be6b86d8ad154e5c2def4da6d2f0aa5266163823291"
         },
         docker_image="multiversx/sdk-rust-contract-builder:v5.3.0"
     )

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -9,7 +9,7 @@ from integration_tests.shared import download_project_repository, run_docker
 
 def main(cli_args: List[str]):
     repository_url = "https://github.com/multiversx/mx-reproducible-contract-build-example-sc"
-    tag = "0.4.7"
+    tag = "0.5.0-beta.0"
     archve_subfolder = f"mx-reproducible-contract-build-example-sc-{tag}"
     project_path = download_project_repository(f"{repository_url}/archive/refs/tags/v{tag}.zip", archve_subfolder)
     project_path = project_path / archve_subfolder

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -9,7 +9,7 @@ from integration_tests.shared import download_project_repository, run_docker
 
 def main(cli_args: List[str]):
     # TODO: when possible, also add multiversx/mx-exchange-sc (as of May 2023, it references mx-sdk-rs < v0.41.0, thus cannot be used for testing reproducible builds v5).
-    project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.0.zip", "mx-exchange-sc-main")
+    project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.6.zip", "mx-exchange-sc-main")
     parent_output_using_project = PARENT_OUTPUT_FOLDER / "using-project"
     parent_output_using_packaged_src = PARENT_OUTPUT_FOLDER / "using-packaged-src"
 

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -9,7 +9,7 @@ from integration_tests.shared import download_project_repository, run_docker
 
 def main(cli_args: List[str]):
     repository_url = "https://github.com/multiversx/mx-reproducible-contract-build-example-sc"
-    tag = "0.4.7-beta.1"
+    tag = "0.4.7"
     archve_subfolder = f"mx-reproducible-contract-build-example-sc-{tag}"
     project_path = download_project_repository(f"{repository_url}/archive/refs/tags/v{tag}.zip", archve_subfolder)
     project_path = project_path / archve_subfolder

--- a/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
+++ b/integration_tests/test_project_folder_and_packaged_src_are_equivalent.py
@@ -8,64 +8,83 @@ from integration_tests.shared import download_project_repository, run_docker
 
 
 def main(cli_args: List[str]):
-    # TODO: when possible, also add multiversx/mx-exchange-sc (as of May 2023, it references mx-sdk-rs < v0.41.0, thus cannot be used for testing reproducible builds v5).
-    project_path = download_project_repository("https://github.com/multiversx/mx-reproducible-contract-build-example-sc/archive/refs/tags/v0.4.6.zip", "mx-exchange-sc-main")
-    parent_output_using_project = PARENT_OUTPUT_FOLDER / "using-project"
-    parent_output_using_packaged_src = PARENT_OUTPUT_FOLDER / "using-packaged-src"
+    repository_url = "https://github.com/multiversx/mx-reproducible-contract-build-example-sc"
+    tag = "0.4.6"
+    archve_subfolder = f"mx-reproducible-contract-build-example-sc-{tag}"
+    project_path = download_project_repository(f"{repository_url}/archive/refs/tags/v{tag}.zip", archve_subfolder)
+    project_path = project_path / archve_subfolder
 
-    shutil.rmtree(parent_output_using_project, ignore_errors=True)
-    shutil.rmtree(parent_output_using_packaged_src, ignore_errors=True)
+    check_project_folder_and_packaged_src_are_equivalent(
+        project_path=project_path,
+        package_whole_project_src=True,
+        parent_output_folder=PARENT_OUTPUT_FOLDER,
+        contracts=["adder", "multisig"],
+    )
 
-    check_project_folder_and_packaged_src_are_equivalent(project_path, parent_output_using_project, parent_output_using_packaged_src, ["adder", "multisig"])
+    check_project_folder_and_packaged_src_are_equivalent(
+        project_path=project_path,
+        package_whole_project_src=False,
+        parent_output_folder=PARENT_OUTPUT_FOLDER,
+        contracts=["adder", "multisig"],
+    )
 
 
 def check_project_folder_and_packaged_src_are_equivalent(
         project_path: Path,
-        parent_output_using_project: Path,
-        parent_output_using_packaged_src: Path,
+        package_whole_project_src: bool,
+        parent_output_folder: Path,
         contracts: List[str]):
     for contract in contracts:
-        for package_whole_project_src in [True, False]:
-            output_using_project = parent_output_using_project / contract / ("whole" if package_whole_project_src else "truncated")
-            output_using_packaged_src = parent_output_using_packaged_src / contract / ("whole" if package_whole_project_src else "truncated")
+        output_using_project = parent_output_folder / "using-project" / contract / ("whole" if package_whole_project_src else "truncated")
+        output_using_packaged_src = parent_output_folder / "using-packaged-src" / contract / ("whole" if package_whole_project_src else "truncated")
 
-            output_using_packaged_src.mkdir(parents=True, exist_ok=True)
-            output_using_project.mkdir(parents=True, exist_ok=True)
+        shutil.rmtree(output_using_project, ignore_errors=True)
+        shutil.rmtree(output_using_packaged_src, ignore_errors=True)
 
-            run_docker(
-                project_path=project_path,
-                package_whole_project_src=package_whole_project_src,
-                packaged_src_path=None,
-                contract_name=contract,
-                image="sdk-rust-contract-builder:next",
-                output_folder=output_using_project
-            )
+        output_using_project.mkdir(parents=True, exist_ok=True)
+        output_using_packaged_src.mkdir(parents=True, exist_ok=True)
 
-            packaged_src_path = output_using_project / f"{contract}/{contract}-0.0.0.source.json"
+        run_docker(
+            project_path=project_path,
+            package_whole_project_src=package_whole_project_src,
+            packaged_src_path=None,
+            contract_name=contract,
+            image="sdk-rust-contract-builder:next",
+            output_folder=output_using_project
+        )
 
-            run_docker(
-                project_path=None,
-                package_whole_project_src=package_whole_project_src,
-                packaged_src_path=packaged_src_path,
-                contract_name=contract,
-                image="sdk-rust-contract-builder:next",
-                output_folder=output_using_packaged_src
-            )
+        packaged_src_path = output_using_project / f"{contract}/{contract}-0.0.0.source.json"
 
-            # Check that output folders are identical
-            using_project_output_files = sorted((output_using_project / contract).rglob("*"))
-            using_packaged_src_output_files = sorted((output_using_packaged_src / contract).rglob("*"))
+        run_docker(
+            project_path=None,
+            package_whole_project_src=package_whole_project_src,
+            packaged_src_path=packaged_src_path,
+            contract_name=contract,
+            image="sdk-rust-contract-builder:next",
+            output_folder=output_using_packaged_src
+        )
 
-            assert len(using_project_output_files) == len(using_packaged_src_output_files)
+        # Check that output folders are identical
+        using_project_output_files = sorted((output_using_project / contract).rglob("*"))
+        using_packaged_src_output_files = sorted((output_using_packaged_src / contract).rglob("*"))
 
-            for index, file in enumerate(using_project_output_files):
-                if not file.is_file() or file.suffix == ".zip":
-                    continue
-                using_project_file_content = file.read_bytes()
-                using_packaged_src_file_content = using_packaged_src_output_files[index].read_bytes()
+        assert len(using_project_output_files) == len(using_packaged_src_output_files)
 
-                if using_project_file_content != using_packaged_src_file_content:
-                    raise Exception(f"Files differ ({contract}): {file.name}")
+        for index, file_using_project in enumerate(using_project_output_files):
+            file_using_packaged_src = using_packaged_src_output_files[index]
+
+            if not file_using_project.is_file() or file_using_project.suffix == ".zip":
+                continue
+            file_content_using_project = file_using_project.read_bytes()
+            file_content_using_packaged_src = file_using_packaged_src.read_bytes()
+
+            if file_content_using_project == file_content_using_packaged_src:
+                print(f"Files are identical ({contract}): {file_using_project.name}")
+            else:
+                print(f"Files differ ({contract}):")
+                print(f"  {file_using_project}")
+                print(f"  {file_using_packaged_src}")
+                raise Exception(f"Files differ ({contract}): {file_using_project.name}")
 
 
 if __name__ == "__main__":

--- a/multiversx_sdk_rust_contract_builder/source_code.py
+++ b/multiversx_sdk_rust_contract_builder/source_code.py
@@ -63,7 +63,7 @@ def _is_source_code_file(path: Path) -> bool:
         return True
     if path.parent.name == "meta" and path.name == "Cargo.lock":
         return False
-    if path.name in ["Cargo.toml", "Cargo.lock", "multicontract.toml", CONTRACT_CONFIG_FILENAME]:
+    if path.name in ["Cargo.toml", "Cargo.lock", "multicontract.toml", "sc-config.toml", CONTRACT_CONFIG_FILENAME]:
         return True
     return False
 


### PR DESCRIPTION
 - Newer rust: `nightly-2023-12-11`.
 - Handle `sc-config.toml`, as well.

Also see:
 - https://github.com/multiversx/mx-sdk-py-cli/issues/383
 - https://t.me/MultiversXDevelopers/122082
 - https://github.com/multiversx/mx-docs/pull/788
 - https://github.com/multiversx/mx-reproducible-contract-build-example-sc/pull/21