### PR TITLE
Update versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:22.04
 
 # Constants
-ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v6.1.2"
-ARG VERSION_RUST="nightly-2023-12-11"
+ARG BUILDER_NAME="multiversx/sdk-rust-contract-builder:v6.2.0"
+ARG VERSION_RUST="stable"
 ARG VERSION_BINARYEN="version_112"
 ARG DOWNLOAD_URL_BINARYEN="https://github.com/WebAssembly/binaryen/releases/download/${VERSION_BINARYEN}/binaryen-${VERSION_BINARYEN}-x86_64-linux.tar.gz"
 ARG VERSION_WABT="1.0.27-1"
-ARG VERSION_SC_META="0.43.3"
+ARG VERSION_SC_META="0.50.3"
 ARG TARGETPLATFORM
 
 # Install system dependencies


### PR DESCRIPTION
Builds using > `0.50.2` of `mx-sdk-rs` fail due to not having diagnostics attributes available in nightly. However, it is available in the latest rust stable release: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#diagnostic-attributes

This PR is mostly a reminder to update versions to the latest & stable – feel free to merge or push further changes.