### PR TITLE
Stricter checks: not possible to build anymore if any cargo lock file is missing (part 1)

### DIFF
--- a/multiversx_sdk_rust_contract_builder/builder.py
+++ b/multiversx_sdk_rust_contract_builder/builder.py
@@ -9,8 +9,8 @@ from multiversx_sdk_rust_contract_builder import source_code
 from multiversx_sdk_rust_contract_builder.build_metadata import BuildMetadata
 from multiversx_sdk_rust_contract_builder.build_options import BuildOptions
 from multiversx_sdk_rust_contract_builder.build_outcome import BuildOutcome
-from multiversx_sdk_rust_contract_builder.cargo_toml import (
-    get_contract_name_and_version, promote_cargo_lock_to_contract_folder)
+from multiversx_sdk_rust_contract_builder.cargo_toml import \
+    get_contract_name_and_version
 from multiversx_sdk_rust_contract_builder.codehash import \
     generate_code_hash_artifact
 from multiversx_sdk_rust_contract_builder.constants import (
@@ -65,10 +65,7 @@ def build_project(
         # We do not clean the "output" folder, since it will be included in one of the generated archives.
         clean_contract(contract_build_subfolder, clean_output=False)
 
-        # If this is the first build of the contract, Cargo.lock will be missing. We need to copy it from the container to host folder.
-        promote_cargo_lock_to_contract_folder(contract_build_subfolder, contract_folder)
-
-        # The bundle (packaged source code) is created after build, so that Cargo.lock files are included (if previously missing).
+        # We create the source code bundle (packaged source code) - could have been created before the build, as well.
         create_packaged_source_code(
             parent_project_folder=project_within_build_folder,
             contract_folder=contract_build_subfolder,
@@ -132,7 +129,6 @@ def clean_contract(folder: Path, clean_output: bool = True):
 def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Path, no_wasm_opt: bool):
     cargo_output_folder = build_folder / "output"
     meta_folder = build_folder / "meta"
-    cargo_lock = build_folder / "wasm" / "Cargo.lock"
 
     args = ["cargo", "run", "build"]
     args.extend(["--target-dir", str(cargo_target_dir)])
@@ -140,8 +136,7 @@ def build_contract(build_folder: Path, output_folder: Path, cargo_target_dir: Pa
 
     # If the lock file is missing, or it needs to be updated, Cargo will exit with an error.
     # See: https://doc.rust-lang.org/cargo/commands/cargo-build.html
-    if cargo_lock.exists():
-        args.append("--locked")
+    args.append("--locked")
 
     custom_env = os.environ.copy()
     # Cargo will use the git executable to fetch registry indexes and git dependencies.

--- a/multiversx_sdk_rust_contract_builder/cargo_toml.py
+++ b/multiversx_sdk_rust_contract_builder/cargo_toml.py
@@ -1,4 +1,3 @@
-import shutil
 from pathlib import Path
 from typing import Tuple
 
@@ -12,9 +11,3 @@ def get_contract_name_and_version(contract_folder: Path) -> Tuple[str, str]:
     name = data["package"]["name"]
     version = data["package"]["version"]
     return name, version
-
-
-def promote_cargo_lock_to_contract_folder(build_folder: Path, contract_folder: Path):
-    from_path = build_folder / "wasm" / "Cargo.lock"
-    to_path = contract_folder / "wasm" / "Cargo.lock"
-    shutil.copy(from_path, to_path)


### PR DESCRIPTION
Previously, the reproducible builds flow allowed the project to have missing **Cargo.lock** files - the newly obtained **Cargo.lock** files were promoted into the project upon build.

Now, a project with missing **Cargo.lock** files cannot be fed to the builder anymore - illegal. Example of error:
```
error: the lock file /tmp/project/contracts/adder/wasm/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

Of course, `mx-sc-actions` did not allow one to have missing **Cargo.lock** files:
 - https://github.com/multiversx/mx-sc-actions/blob/main/.github/workflows/reproducible-build.yml#L89

 **Thus, in most use cases this change will not be seen as a breaking change.**